### PR TITLE
add support for type application/wmo-GRIB2

### DIFF
--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -29,6 +29,7 @@ import diskcache
 
 _SETTINGS: Dict[str, Any] = {
     "directory": os.path.join(tempfile.gettempdir(), "cacholote"),  # cache directory
+    "xarray_cache_type": "application/netcdf",
     "timeout": 60,  # SQLite connection timeout
     "statistics": 1,  # True
     "tag_index": 0,  # False
@@ -43,6 +44,7 @@ _SETTINGS: Dict[str, Any] = {
     "disk_min_file_size": 2**15,  # 32kb
     "disk_pickle_protocol": pickle.HIGHEST_PROTOCOL,
 }
+EXTENSIONS = {"application/netcdf": ".nc", "application/wmo-GRIB2": ".grb2"}
 
 
 def initialize_cache_store() -> diskcache.Cache:
@@ -76,6 +78,12 @@ class set:
             for key in _SETTINGS.keys() - kwargs.keys():
                 if isinstance(getattr(type(new_cache_store), key, None), property):
                     kwargs[key] = getattr(new_cache_store, key)
+
+        if (
+            "xarray_cache_type" in kwargs
+            and kwargs["xarray_cache_type"] not in EXTENSIONS
+        ):
+            raise ValueError(f"'xarray_cache_type' must be one of {list(EXTENSIONS)}")
 
         try:
             self._old = {key: _SETTINGS[key] for key in kwargs}

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -40,7 +40,10 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         args = obj.get("args", ())
         kwargs = obj.get("kwargs", {})
         return func(*args, **kwargs)
-    elif obj.get("type") == "application/netcdf" and "file:local_path" in obj:
+    elif (
+        obj.get("type") in ["application/netcdf", "application/wmo-GRIB2"]
+        and "file:local_path" in obj
+    ):
         import xarray as xr
 
         open_kwargs = obj.get("xarray:open_kwargs", {})

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -17,6 +17,8 @@ import importlib
 import json
 from typing import Any, Dict, Union
 
+from . import config
+
 
 def import_object(fully_qualified_name: str) -> Any:
     # FIXME: apply exclude/include-rules to `fully_qualified_name`
@@ -40,10 +42,7 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         args = obj.get("args", ())
         kwargs = obj.get("kwargs", {})
         return func(*args, **kwargs)
-    elif (
-        obj.get("type") in ["application/netcdf", "application/wmo-GRIB2"]
-        and "file:local_path" in obj
-    ):
+    elif obj.get("type") in config.EXTENSIONS and "file:local_path" in obj:
         import xarray as xr
 
         open_kwargs = obj.get("xarray:open_kwargs", {})

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -17,8 +17,6 @@ import importlib
 import json
 from typing import Any, Dict, Union
 
-from . import config
-
 
 def import_object(fully_qualified_name: str) -> Any:
     # FIXME: apply exclude/include-rules to `fully_qualified_name`
@@ -34,7 +32,8 @@ def import_object(fully_qualified_name: str) -> Any:
 def object_hook(obj: Dict[str, Any]) -> Any:
     if obj.get("type") == "python_object" and "fully_qualified_name" in obj:
         return import_object(obj["fully_qualified_name"])
-    elif obj.get("type") == "python_call" and "callable" in obj:
+
+    if obj.get("type") == "python_call" and "callable" in obj:
         if callable(obj["callable"]):
             func = obj["callable"]
         else:
@@ -42,7 +41,8 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         args = obj.get("args", ())
         kwargs = obj.get("kwargs", {})
         return func(*args, **kwargs)
-    elif obj.get("type") in config.EXTENSIONS and "file:local_path" in obj:
+
+    if {"xarray:open_kwargs", "file:local_path"} <= set(obj):
         import xarray as xr
 
         open_kwargs = obj.get("xarray:open_kwargs", {})
@@ -54,6 +54,11 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         else:
             store = obj["file:local_path"]
         return xr.open_dataset(store, **open_kwargs)
+
+    if {"tmp:open_kwargs", "file:local_path"} <= set(obj):
+
+        return open(obj["file:local_path"], **obj["tmp:open_kwargs"])
+
     return obj
 
 

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -68,16 +68,9 @@ def dictify_python_call(
     return python_call_simple
 
 
-def dictify_xarray_asset(
-    checksum: str,
-    size: int,
-    open_kwargs: Dict[str, Any] = {},
-    storage_options: Dict[str, Any] = {},
+def dictify_file(
+    filetype: str, checksum: str, size: int, extension: str = ""
 ) -> Dict[str, Any]:
-
-    filetype = config.SETTINGS["xarray_cache_type"]
-    extension = config.EXTENSIONS[filetype]
-
     return {
         "type": filetype,
         "href": f"./{checksum}{extension}",
@@ -87,9 +80,45 @@ def dictify_xarray_asset(
             pathlib.Path(config.SETTINGS["directory"]).absolute()
             / f"{checksum}{extension}"
         ),
-        "xarray:open_kwargs": open_kwargs,
-        "xarray:storage_options": storage_options,
     }
+
+
+def dictify_io_asset(
+    filetype: str,
+    checksum: str,
+    size: int,
+    extension: str = "",
+    open_kwargs: Dict[str, Any] = {},
+) -> Dict[str, Any]:
+
+    asset_dict = dictify_file(
+        filetype=filetype, checksum=checksum, size=size, extension=extension
+    )
+    asset_dict.update({"tmp:open_kwargs": open_kwargs})
+    return asset_dict
+
+
+def dictify_xarray_asset(
+    checksum: str,
+    size: int,
+    open_kwargs: Dict[str, Any] = {},
+    storage_options: Dict[str, Any] = {},
+) -> Dict[str, Any]:
+
+    asset_dict = dictify_file(
+        filetype=config.SETTINGS["xarray_cache_type"],
+        checksum=checksum,
+        size=size,
+        extension=config.EXTENSIONS[config.SETTINGS["xarray_cache_type"]],
+    )
+    asset_dict.update(
+        {
+            "xarray:open_kwargs": open_kwargs,
+            "xarray:storage_options": storage_options,
+        }
+    )
+
+    return asset_dict
 
 
 def dictify_datetime(obj: datetime.datetime) -> Dict[str, Any]:

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -69,29 +69,23 @@ def dictify_python_call(
 
 
 def dictify_xarray_asset(
-    filetype: str,
     checksum: str,
     size: int,
     open_kwargs: Dict[str, Any] = {},
     storage_options: Dict[str, Any] = {},
 ) -> Dict[str, Any]:
 
-    if filetype == "application/netcdf":
-        extension = ".nc"
-    elif filetype == "application/wmo-GRIB2":
-        extension = ".grb2"
-    else:
-
-        extension = f".{filetype.split('/')[-1]}"
-    href = f"./{checksum}{extension}"
+    filetype = config.SETTINGS["xarray_cache_type"]
+    extension = config.EXTENSIONS[filetype]
 
     return {
         "type": filetype,
-        "href": href,
+        "href": f"./{checksum}{extension}",
         "file:checksum": checksum,
         "file:size": size,
         "file:local_path": str(
-            pathlib.Path(config.SETTINGS["directory"]).absolute() / href
+            pathlib.Path(config.SETTINGS["directory"]).absolute()
+            / f"{checksum}{extension}"
         ),
         "xarray:open_kwargs": open_kwargs,
         "xarray:storage_options": storage_options,

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -54,7 +54,8 @@ def dictify_xr_dataset(
                 obj, xr_json["file:local_path"], grib_keys={"edition": 2}
             )
         else:
-            raise ValueError(f"Type {xr_json['type']} is NOT supported.")
+            # Should never get here! xarray_cache_type is checked in config.py
+            raise ValueError(f"type {xr_json['type']} is NOT supported.")
     return xr_json
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -12,10 +12,12 @@ dependencies:
 - sphinx
 - sphinx-autoapi
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW
+- cfgrib
 - dask
 - diskcache
 - netCDF4
 - pip
+- pooch
 - xarray>=2022.6.0
 - zarr
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
 - netCDF4
 - pip
 - pooch
+- python-magic
 - xarray>=2022.6.0
 - zarr
 - pip:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,3 @@ ignore_missing_imports = True
 
 [mypy-redislite.*]
 ignore_missing_imports = True
-
-[mypy-zarr.*]
-ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,16 +32,19 @@ strict = True
 cacholote =
     py.typed
 
+[mypy-cfgrib.*]
+ignore_missing_imports = True
+
 [mypy-diskcache.*]
 ignore_missing_imports = True
 
 [mypy-fsspec.*]
 ignore_missing_imports = True
 
-[mypy-redislite.*]
+[mypy-pooch.*]
 ignore_missing_imports = True
 
-[mypy-s3fs.*]
+[mypy-redislite.*]
 ignore_missing_imports = True
 
 [mypy-zarr.*]

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -8,8 +8,9 @@ from cacholote import cache, config, decode, encode, extra_encoders
 
 try:
     import xarray as xr
-except ImportError:
+finally:
     pytest.importorskip("xarray")
+    pytest.importorskip("dask")
 
 T = TypeVar("T")
 
@@ -105,35 +106,3 @@ def test_xr_cacheable(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
             xr.testing.assert_equal(res, ds)
         else:
             xr.testing.assert_identical(res, ds)
-
-
-def test_copy_file_to_cache_directory(tmpdir: str) -> None:
-    tmpfile = os.path.join(tmpdir, "dummy.txt")
-    cached_file = os.path.join(
-        tmpdir, "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7.txt"
-    )
-
-    with open(tmpfile, "w") as f:
-        f.write("dummy")
-    cfunc = cache.cacheable(func)
-
-    res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    with open(cached_file, "r") as f:
-        assert f.read() == "dummy"
-    assert config.SETTINGS["cache_store"].stats() == (0, 1)
-
-    # skip copying a file already in cache directory
-    mtime = os.path.getmtime(cached_file)
-    res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    assert mtime == os.path.getmtime(cached_file)
-    assert config.SETTINGS["cache_store"].stats() == (1, 1)
-
-    # do not crash if cached file is removed
-    os.remove(cached_file)
-    with pytest.warns(UserWarning):
-        res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    assert os.path.exists(cached_file)
-    assert config.SETTINGS["cache_store"].stats() == (2, 1)

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -1,0 +1,69 @@
+import os
+from typing import TypeVar
+
+import pytest
+
+from cacholote import cache, config, extra_encoders
+
+pytest.importorskip("magic")
+
+T = TypeVar("T")
+
+
+def func(a: T) -> T:
+    return a
+
+
+def test_dictify_io_object(tmpdir: str) -> None:
+    tmpfile = os.path.join(tmpdir, "dummy.txt")
+    with open(tmpfile, "w") as f:
+        f.write("dummy")
+
+    local_path = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+    )
+    expected = {
+        "type": "text/plain",
+        "href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
+        "file:size": 5,
+        "file:local_path": local_path,
+        "tmp:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
+    }
+    res = extra_encoders.dictify_io_object(open(tmpfile))
+    assert res == expected
+    assert os.path.exists(local_path)
+
+
+def test_copy_file_to_cache_directory(tmpdir: str) -> None:
+    tmpfile = os.path.join(tmpdir, "dummy.txt")
+    cached_file = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7.txt",
+    )
+
+    with open(tmpfile, "w") as f:
+        f.write("dummy")
+    cfunc = cache.cacheable(func)
+
+    res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    with open(cached_file, "r") as f:
+        assert f.read() == "dummy"
+    assert config.SETTINGS["cache_store"].stats() == (0, 1)
+
+    # skip copying a file already in cache directory
+    mtime = os.path.getmtime(cached_file)
+    res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    assert mtime == os.path.getmtime(cached_file)
+    assert config.SETTINGS["cache_store"].stats() == (1, 1)
+
+    # do not crash if cached file is removed
+    os.remove(cached_file)
+    with pytest.warns(UserWarning):
+        res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    assert os.path.exists(cached_file)
+    assert config.SETTINGS["cache_store"].stats() == (2, 1)


### PR DESCRIPTION
This PR allows to write xarray objects if format `application/wmo-GRIB2`. It also sets the environment to eventually support `zarr` format.

I removed the `zarr` and `s3` specific functions as we should be able to achieve the same using just xarray with fsspec (note that stac's extension for `xarray` allows to specify additional argumets to pass to `fsspec.get_mapper`).

At the moment I'm testing with a sample dataset taken from `cfgrib`.