### PR TITLE
Improve io caching

### DIFF
--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -55,9 +55,9 @@ def object_hook(obj: Dict[str, Any]) -> Any:
             store = obj["file:local_path"]
         return xr.open_dataset(store, **open_kwargs)
 
-    if {"io:open_kwargs", "file:local_path"} <= set(obj):
+    if {"tmp:open_kwargs", "file:local_path"} <= set(obj):
 
-        return open(obj["file:local_path"], **obj["io:open_kwargs"])
+        return open(obj["file:local_path"], **obj["tmp:open_kwargs"])
 
     return obj
 

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -17,8 +17,6 @@ import importlib
 import json
 from typing import Any, Dict, Union
 
-from . import config
-
 
 def import_object(fully_qualified_name: str) -> Any:
     # FIXME: apply exclude/include-rules to `fully_qualified_name`
@@ -34,7 +32,8 @@ def import_object(fully_qualified_name: str) -> Any:
 def object_hook(obj: Dict[str, Any]) -> Any:
     if obj.get("type") == "python_object" and "fully_qualified_name" in obj:
         return import_object(obj["fully_qualified_name"])
-    elif obj.get("type") == "python_call" and "callable" in obj:
+
+    if obj.get("type") == "python_call" and "callable" in obj:
         if callable(obj["callable"]):
             func = obj["callable"]
         else:
@@ -42,7 +41,8 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         args = obj.get("args", ())
         kwargs = obj.get("kwargs", {})
         return func(*args, **kwargs)
-    elif obj.get("type") in config.EXTENSIONS and "file:local_path" in obj:
+
+    if {"xarray:open_kwargs", "file:local_path"} <= set(obj):
         import xarray as xr
 
         open_kwargs = obj.get("xarray:open_kwargs", {})
@@ -54,6 +54,11 @@ def object_hook(obj: Dict[str, Any]) -> Any:
         else:
             store = obj["file:local_path"]
         return xr.open_dataset(store, **open_kwargs)
+
+    if {"io:open_kwargs", "file:local_path"} <= set(obj):
+
+        return open(obj["file:local_path"], **obj["io:open_kwargs"])
+
     return obj
 
 

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -90,9 +90,12 @@ def dictify_io_asset(
     extension: str = "",
     open_kwargs: Dict[str, Any] = {},
 ) -> Dict[str, Any]:
-    file_kwargs = locals()
-    extra_kwargs = {"io:open_kwargs": file_kwargs.pop("open_kwargs")}
-    return {**dictify_file(**file_kwargs), **extra_kwargs}
+
+    asset_dict = dictify_file(
+        filetype=filetype, checksum=checksum, size=size, extension=extension
+    )
+    asset_dict.update({"tmp:open_kwargs": open_kwargs})
+    return asset_dict
 
 
 def dictify_xarray_asset(
@@ -102,19 +105,20 @@ def dictify_xarray_asset(
     storage_options: Dict[str, Any] = {},
 ) -> Dict[str, Any]:
 
-    file_kwargs = locals()
-    file_kwargs.update(
+    asset_dict = dictify_file(
+        filetype=config.SETTINGS["xarray_cache_type"],
+        checksum=checksum,
+        size=size,
+        extension=config.EXTENSIONS[config.SETTINGS["xarray_cache_type"]],
+    )
+    asset_dict.update(
         {
-            "filetype": config.SETTINGS["xarray_cache_type"],
-            "extension": config.EXTENSIONS[config.SETTINGS["xarray_cache_type"]],
+            "xarray:open_kwargs": open_kwargs,
+            "xarray:storage_options": storage_options,
         }
     )
-    extra_kwargs = {
-        "xarray:open_kwargs": file_kwargs.pop("open_kwargs"),
-        "xarray:storage_options": file_kwargs.pop("storage_options"),
-    }
 
-    return {**dictify_file(**file_kwargs), **extra_kwargs}
+    return asset_dict
 
 
 def dictify_datetime(obj: datetime.datetime) -> Dict[str, Any]:

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
 - netCDF4
 - pip
 - pooch
+- python-magic
 - xarray>=2022.6.0
 - zarr
 - pip:

--- a/tests/test_40_extra_encoders.py
+++ b/tests/test_40_extra_encoders.py
@@ -107,6 +107,28 @@ def test_xr_cacheable(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
             xr.testing.assert_identical(res, ds)
 
 
+def test_dictify_io_object(tmpdir: str) -> None:
+    tmpfile = os.path.join(tmpdir, "dummy.txt")
+    with open(tmpfile, "w") as f:
+        f.write("dummy")
+
+    local_path = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+    )
+    expected = {
+        "type": "text/plain",
+        "href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
+        "file:size": 5,
+        "file:local_path": local_path,
+        "io:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
+    }
+    res = extra_encoders.dictify_io_object(open(tmpfile))
+    assert res == expected
+    assert os.path.exists(local_path)
+
+
 def test_copy_file_to_cache_directory(tmpdir: str) -> None:
     tmpfile = os.path.join(tmpdir, "dummy.txt")
     cached_file = os.path.join(

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -10,6 +10,7 @@ try:
     import xarray as xr
 except ImportError:
     pytest.importorskip("xarray")
+    pytest.importorskip("dask")
 
 T = TypeVar("T")
 
@@ -105,57 +106,3 @@ def test_xr_cacheable(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
             xr.testing.assert_equal(res, ds)
         else:
             xr.testing.assert_identical(res, ds)
-
-
-def test_dictify_io_object(tmpdir: str) -> None:
-    tmpfile = os.path.join(tmpdir, "dummy.txt")
-    with open(tmpfile, "w") as f:
-        f.write("dummy")
-
-    local_path = os.path.join(
-        config.SETTINGS["cache_store"].directory,
-        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
-    )
-    expected = {
-        "type": "text/plain",
-        "href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
-        "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
-        "file:size": 5,
-        "file:local_path": local_path,
-        "io:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
-    }
-    res = extra_encoders.dictify_io_object(open(tmpfile))
-    assert res == expected
-    assert os.path.exists(local_path)
-
-
-def test_copy_file_to_cache_directory(tmpdir: str) -> None:
-    tmpfile = os.path.join(tmpdir, "dummy.txt")
-    cached_file = os.path.join(
-        tmpdir, "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7.txt"
-    )
-
-    with open(tmpfile, "w") as f:
-        f.write("dummy")
-    cfunc = cache.cacheable(func)
-
-    res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    with open(cached_file, "r") as f:
-        assert f.read() == "dummy"
-    assert config.SETTINGS["cache_store"].stats() == (0, 1)
-
-    # skip copying a file already in cache directory
-    mtime = os.path.getmtime(cached_file)
-    res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    assert mtime == os.path.getmtime(cached_file)
-    assert config.SETTINGS["cache_store"].stats() == (1, 1)
-
-    # do not crash if cached file is removed
-    os.remove(cached_file)
-    with pytest.warns(UserWarning):
-        res = cfunc(open(tmpfile))
-    assert res.read() == "dummy"
-    assert os.path.exists(cached_file)
-    assert config.SETTINGS["cache_store"].stats() == (2, 1)

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -8,7 +8,7 @@ from cacholote import cache, config, decode, encode, extra_encoders
 
 try:
     import xarray as xr
-except ImportError:
+finally:
     pytest.importorskip("xarray")
     pytest.importorskip("dask")
 

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -29,7 +29,7 @@ def test_dictify_io_object(tmpdir: str) -> None:
         "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
         "file:size": 5,
         "file:local_path": local_path,
-        "io:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
+        "tmp:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
     }
     res = extra_encoders.dictify_io_object(open(tmpfile))
     assert res == expected

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -1,0 +1,69 @@
+import os
+from typing import TypeVar
+
+import pytest
+
+from cacholote import cache, config, extra_encoders
+
+pytest.importorskip("magic")
+
+T = TypeVar("T")
+
+
+def func(a: T) -> T:
+    return a
+
+
+def test_dictify_io_object(tmpdir: str) -> None:
+    tmpfile = os.path.join(tmpdir, "dummy.txt")
+    with open(tmpfile, "w") as f:
+        f.write("dummy")
+
+    local_path = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+    )
+    expected = {
+        "type": "text/plain",
+        "href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
+        "file:size": 5,
+        "file:local_path": local_path,
+        "io:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
+    }
+    res = extra_encoders.dictify_io_object(open(tmpfile))
+    assert res == expected
+    assert os.path.exists(local_path)
+
+
+def test_copy_file_to_cache_directory(tmpdir: str) -> None:
+    tmpfile = os.path.join(tmpdir, "dummy.txt")
+    cached_file = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7.txt",
+    )
+
+    with open(tmpfile, "w") as f:
+        f.write("dummy")
+    cfunc = cache.cacheable(func)
+
+    res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    with open(cached_file, "r") as f:
+        assert f.read() == "dummy"
+    assert config.SETTINGS["cache_store"].stats() == (0, 1)
+
+    # skip copying a file already in cache directory
+    mtime = os.path.getmtime(cached_file)
+    res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    assert mtime == os.path.getmtime(cached_file)
+    assert config.SETTINGS["cache_store"].stats() == (1, 1)
+
+    # do not crash if cached file is removed
+    os.remove(cached_file)
+    with pytest.warns(UserWarning):
+        res = cfunc(open(tmpfile))
+    assert res.read() == "dummy"
+    assert os.path.exists(cached_file)
+    assert config.SETTINGS["cache_store"].stats() == (2, 1)


### PR DESCRIPTION
This PR allows to cache any file using a JSON similar to xarray's object. For example:
```
"type": "text/plain",
"href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
"file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
"file:size": 5,
"file:local_path": "/path/to/cache/dir/f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
"io:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
```