### PR TITLE
implement fsspec

### DIFF
--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -47,7 +47,7 @@ _initialize_cache_store()
 # Immutable settings to be used by other modules
 SETTINGS = MappingProxyType(_SETTINGS)
 EXTENSIONS = MappingProxyType(
-    {"application/netcdf": ".nc", "application/wmo-GRIB2": ".grb2"}
+    {"application/x-netcdf": ".nc", "application/x-grib": ".grb"}
 )
 
 

--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -101,17 +101,11 @@ class set:
         _SETTINGS.update(self._old)
 
 
-def get_cache_files_directory() -> fsspec.implementations.dirfs.DirFileSystem:
+def get_cache_files_directory() -> str:
 
     if _SETTINGS["cache_files_urlpath"] is _SETTINGS["cache_db_directory"] is None:
         raise ValueError("Please set 'cache_files_directory'")
 
     if _SETTINGS["cache_files_urlpath"] is None:
-        urlpath = _SETTINGS["cache_db_directory"]
-    else:
-        urlpath = _SETTINGS["cache_files_urlpath"]
-    urlpath = str(urlpath)
-
-    protocol = fsspec.utils.get_protocol(urlpath)
-    fs = fsspec.filesystem(protocol, **_SETTINGS["cache_files_storage_options"])
-    return fsspec.implementations.dirfs.DirFileSystem(path=urlpath, fs=fs)
+        return str(_SETTINGS["cache_db_directory"])
+    return str(_SETTINGS["cache_files_urlpath"])

--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -91,10 +91,10 @@ class set:
 
 
 def get_cache_files_directory() -> fsspec.AbstractFileSystem:
-    if _SETTINGS["cache_db_directory"] is None and _SETTINGS["cache_files_directory"]:
-        raise ValueError("Please set 'cache_files_directory' must be set.")
 
     if _SETTINGS["cache_files_directory"] is None:
+        if _SETTINGS["cache_db_directory"] is None:
+            raise ValueError("Please set 'cache_files_directory'")
         return fsspec.implementations.dirfs.DirFileSystem(
             _SETTINGS["cache_db_directory"], fsspec.filesystem("file")
         )

--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -18,72 +18,53 @@ SETTINGS can be imported elsewhere to use global settings.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import os
-import pickle
 import tempfile
 from types import MappingProxyType, TracebackType
 from typing import Any, Dict, Optional, Type
 
 import diskcache
+import fsspec
+import fsspec.implementations.dirfs
 
 _SETTINGS: Dict[str, Any] = {
-    "directory": os.path.join(tempfile.gettempdir(), "cacholote"),  # cache directory
+    "cache_db_directory": os.path.join(tempfile.gettempdir(), "cacholote"),
+    "cache_files_directory": None,
     "xarray_cache_type": "application/netcdf",
-    "timeout": 60,  # SQLite connection timeout
-    "statistics": 1,  # True
-    "tag_index": 0,  # False
-    "eviction_policy": "least-recently-stored",
-    "size_limit": 2**30,  # 1gb
-    "cull_limit": 10,
-    "sqlite_auto_vacuum": 1,  # FULL
-    "sqlite_cache_size": 2**13,  # 8,192 pages
-    "sqlite_journal_mode": "wal",
-    "sqlite_mmap_size": 2**26,  # 64mb
-    "sqlite_synchronous": 1,  # NORMAL
-    "disk_min_file_size": 2**15,  # 32kb
-    "disk_pickle_protocol": pickle.HIGHEST_PROTOCOL,
 }
-EXTENSIONS = {"application/netcdf": ".nc", "application/wmo-GRIB2": ".grb2"}
 
 
-def initialize_cache_store() -> diskcache.Cache:
-    sig = inspect.signature(diskcache.Cache.__init__)
-    kwargs = {
-        k: v
-        for k, v in _SETTINGS.items()
-        if k in diskcache.DEFAULT_SETTINGS or k in sig.parameters.keys()
-    }
-    return diskcache.Cache(**kwargs, disk=diskcache.JSONDisk)
+def _initialize_cache_store() -> None:
+    _SETTINGS["cache_store"] = diskcache.Cache(
+        _SETTINGS["cache_db_directory"], disk=diskcache.JSONDisk, statistics=1
+    )
 
 
-_SETTINGS["cache_store"] = initialize_cache_store()
+_initialize_cache_store()
 
 # Immutable settings to be used by other modules
 SETTINGS = MappingProxyType(_SETTINGS)
+EXTENSIONS = MappingProxyType(
+    {"application/netcdf": ".nc", "application/wmo-GRIB2": ".grb2"}
+)
 
 
 class set:
     # TODO: Add docstring
     def __init__(self, **kwargs: Any):
 
-        if "cache_store" in kwargs:
-            if len(kwargs) != 1:
-                raise ValueError(
-                    "'cache_store' is mutually exclusive with all other settings"
-                )
-
-            # infer settings from cache_store properties
-            new_cache_store = kwargs["cache_store"]
-            for key in _SETTINGS.keys() - kwargs.keys():
-                if isinstance(getattr(type(new_cache_store), key, None), property):
-                    kwargs[key] = getattr(new_cache_store, key)
-
+        if "cache_store" in kwargs and "cache_db_directory" in kwargs:
+            raise ValueError(
+                "'cache_store' and 'cache_db_directory' are mutually exclusive"
+            )
         if (
             "xarray_cache_type" in kwargs
             and kwargs["xarray_cache_type"] not in EXTENSIONS
         ):
             raise ValueError(f"'xarray_cache_type' must be one of {list(EXTENSIONS)}")
+
+        if "cache_store" in kwargs:
+            kwargs["cache_db_directory"] = None
 
         try:
             self._old = {key: _SETTINGS[key] for key in kwargs}
@@ -93,9 +74,9 @@ class set:
             ) from ex
 
         _SETTINGS.update(kwargs)
-        if "cache_store" not in kwargs:
+        if kwargs.get("cache_db_directory", None) is not None:
             self._old["cache_store"] = _SETTINGS["cache_store"]
-            _SETTINGS["cache_store"] = initialize_cache_store()
+            _initialize_cache_store()
 
     def __enter__(self) -> None:
         pass
@@ -107,3 +88,15 @@ class set:
         exc_tb: Optional[TracebackType],
     ) -> None:
         _SETTINGS.update(self._old)
+
+
+def get_cache_files_directory() -> fsspec.AbstractFileSystem:
+    if _SETTINGS["cache_db_directory"] is None and _SETTINGS["cache_files_directory"]:
+        raise ValueError("Please set 'cache_files_directory' must be set.")
+
+    if _SETTINGS["cache_files_directory"] is None:
+        return fsspec.implementations.dirfs.DirFileSystem(
+            _SETTINGS["cache_db_directory"], fsspec.filesystem("file")
+        )
+
+    return _SETTINGS["cache_files_directory"]

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -17,6 +17,8 @@ import importlib
 import json
 from typing import Any, Dict, Union
 
+from . import config
+
 
 def import_object(fully_qualified_name: str) -> Any:
     # FIXME: apply exclude/include-rules to `fully_qualified_name`
@@ -57,7 +59,9 @@ def object_hook(obj: Dict[str, Any]) -> Any:
 
     if {"tmp:open_kwargs", "file:local_path"} <= set(obj):
 
-        return open(obj["file:local_path"], **obj["tmp:open_kwargs"])
+        return config.get_cache_files_directory().open(
+            obj["href"], **obj["tmp:open_kwargs"]
+        )
 
     return obj
 

--- a/cacholote/decode.py
+++ b/cacholote/decode.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, Union
 
 import fsspec
 
+from . import extra_encoders
+
 
 def import_object(fully_qualified_name: str) -> Any:
     # FIXME: apply exclude/include-rules to `fully_qualified_name`
@@ -57,9 +59,7 @@ def object_hook(obj: Dict[str, Any]) -> Any:
 
     if {"tmp:open_kwargs", "tmp:storage_options"} <= set(obj):
 
-        return fsspec.open(
-            obj["href"], **obj["tmp:open_kwargs"], **obj["tmp:storage_options"]
-        ).open()
+        return extra_encoders.open_io_from_json(obj)
 
     return obj
 

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -74,9 +74,7 @@ def dictify_python_call(
 def dictify_file(
     filetype: str, checksum: str, size: int, extension: str = ""
 ) -> Dict[str, Any]:
-    href = posixpath.join(
-        config.get_cache_files_directory().storage_options["path"], checksum + extension
-    )
+    href = posixpath.join(config.get_cache_files_directory(), checksum + extension)
     file_json = {
         "type": filetype,
         "href": href,

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -71,14 +71,14 @@ def dictify_python_call(
 def dictify_file(
     filetype: str, checksum: str, size: int, extension: str = ""
 ) -> Dict[str, Any]:
+    root = config.get_cache_files_directory().path
     return {
         "type": filetype,
         "href": f"./{checksum}{extension}",
         "file:checksum": checksum,
         "file:size": size,
         "file:local_path": str(
-            pathlib.Path(config.SETTINGS["directory"]).absolute()
-            / f"{checksum}{extension}"
+            pathlib.Path(root).absolute() / f"{checksum}{extension}"
         ),
     }
 

--- a/cacholote/encode.py
+++ b/cacholote/encode.py
@@ -72,9 +72,9 @@ def dictify_python_call(
 
 
 def dictify_file(
-    filetype: str, checksum: str, size: int, extension: str = ""
+    filetype: str, checksum: Union[int, str], size: int, extension: str = ""
 ) -> Dict[str, Any]:
-    href = posixpath.join(config.get_cache_files_directory(), checksum + extension)
+    href = posixpath.join(config.get_cache_files_directory(), f"{checksum}{extension}")
     file_json = {
         "type": filetype,
         "href": href,
@@ -89,7 +89,7 @@ def dictify_file(
 
 def dictify_io_asset(
     filetype: str,
-    checksum: str,
+    checksum: Union[int, str],
     size: int,
     extension: str = "",
     open_kwargs: Dict[str, Any] = {},
@@ -108,7 +108,7 @@ def dictify_io_asset(
 
 
 def dictify_xarray_asset(
-    checksum: str,
+    checksum: Union[int, str],
     size: int,
     open_kwargs: Dict[str, Any] = {},
 ) -> Dict[str, Any]:

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -99,7 +99,7 @@ def dictify_io_object(
     delete_original: bool = False,
 ) -> Dict[str, Any]:
 
-    # The typo of obj is io.IOBase because all fsspec open objects are inherited from that.
+    # The type of obj is io.IOBase because all fsspec open objects are inherited from that.
     # The attributes ignored below DO exist in fsspec classes and io.TextIOWrapper and io.BufferedReader.
     if "w" in obj.mode:  # type: ignore[attr-defined]
         raise ValueError("write-mode objects can NOT be cached.")
@@ -136,7 +136,6 @@ def dictify_io_object(
     )
     try:
         open_io_from_json(io_json)
-
     except:  # noqa: E722
         cache_local_path = io_json.get("file:local_path", None)
         cache_dir_fs = config.get_cache_files_directory()
@@ -146,10 +145,10 @@ def dictify_io_object(
         if protocol_in == "file":
             # IN is local
             if cache_local_path is not None and delete_original:
-                # IN and OUT are local
+                # OUT is local
                 fsspec.filesystem("file").move(path_in, cache_local_path)
             else:
-                # IN is local, OUT is not local
+                # OUT is not local
                 cache_dir_fs.put_file(path_in, cache_basename)
                 if delete_original:
                     fsspec.filesystem("file").rm(path_in)
@@ -159,15 +158,15 @@ def dictify_io_object(
                 warnings.warn("Can NOT delete original file.")
 
             with tempfile.TemporaryDirectory() as tmpdirname:
+                # Download loacally in tmp directory
                 with fsspec.open(
                     f"filecache::{path_in}", filecache={"cache_storage": tmpdirname}
                 ) as f:
-                    # Download locally
                     if cache_local_path:
-                        # IN is not local, OUT is local
+                        # OUT is local
                         fsspec.filesystem("file").move(f.name, cache_local_path)
                     else:
-                        # IN is not local, OUT is not local
+                        # OUT is not local
                         cache_dir_fs.put_file(f.name, cache_basename)
 
     return io_json

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -101,24 +101,22 @@ def dictify_io_object(
     params = inspect.signature(open).parameters
     open_kwargs = {k: getattr(obj, k) for k in params.keys() if hasattr(obj, k)}
 
-    io_json = encode.dictify_io_asset(
+    try:
+        config.get_cache_files_directory().open(checksum + extension, **open_kwargs)
+    except:  # noqa: E722
+        config.get_cache_files_directory().put_file(obj.name, checksum + extension)
+        if delete_original:
+            # TODO: when cache is a local file system, then it would be better
+            # to mv rather than put then rm
+            os.remove(obj.name)
+
+    return encode.dictify_io_asset(
         filetype=filetype,
         checksum=checksum,
         size=size,
         extension=extension,
         open_kwargs=open_kwargs,
     )
-
-    try:
-        config.get_cache_files_directory().open(io_json["href"], **open_kwargs)
-    except:  # noqa: E722
-        config.get_cache_files_directory().put_file(obj.name, io_json["href"])
-        if delete_original:
-            # TODO: when cache is a local file system, then it would be better
-            # to mv rather than put then rm
-            os.remove(obj.name)
-
-    return io_json
 
 
 def register_all() -> None:

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -46,13 +46,11 @@ for ext in (".grib", ".grb", ".grb1", ".grb2"):
         mimetypes.add_type("application/x-grib", ext, strict=False)
 
 
-def open_io_from_json(io_json: Dict[str, Any]) -> io.IOBase:
+def open_io_from_json(io_json: Dict[str, Any]) -> fsspec.spec.AbstractBufferedFile:
     fs = fsspec.filesystem(
         fsspec.utils.get_protocol(io_json["href"]), **io_json["tmp:storage_options"]
     )
-    f: io.IOBase = fs.open(io_json["href"], **io_json["tmp:open_kwargs"])
-
-    return f
+    return fs.open(io_json["href"], **io_json["tmp:open_kwargs"])
 
 
 def tokenize_xr_object(obj: Union["xr.DataArray", "xr.Dataset"]) -> str:

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -100,7 +100,7 @@ def dictify_io_object(
     filetype = filetype or "unknown"
 
     size = fs_in.size(path_in)
-    checksum = str(fs_in.checksum(path_in))
+    checksum = fs_in.checksum(path_in)
 
     extension = f".{path_in.rsplit('.', 1)[-1]}" if "." in path_in else ""
 

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -91,14 +91,9 @@ def dictify_io_object(
 
     filetype = magic.from_file(obj.name, mime=True)
 
-    if obj.closed:
-        with open(obj.name, "rb") as f:
-            checksum = hexdigestify_file(f)
-    else:
-        checksum = hexdigestify_file(obj)
-
-    size = os.path.getsize(obj.name)
-
+    with fsspec.open(obj.name, "rb") as f:
+        checksum = hexdigestify_file(f)
+        size = f.size
     _, extension = os.path.splitext(obj.name)
 
     params = inspect.signature(open).parameters

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -18,7 +18,6 @@ import inspect
 import io
 import mimetypes
 import tempfile
-import warnings
 from typing import Any, Dict, Union
 
 import fsspec
@@ -149,10 +148,6 @@ def dictify_io_object(
                 if delete_original:
                     fsspec.filesystem("file").rm(path_in)
         else:
-            # IN is not local
-            if delete_original:
-                warnings.warn("Can NOT delete original file.")
-
             with tempfile.TemporaryDirectory() as tmpdirname:
                 # Download loacally in tmp directory
                 with fsspec.open(
@@ -164,7 +159,9 @@ def dictify_io_object(
                     else:
                         # OUT is not local
                         cache_dir_fs.put_file(f.name, cache_basename)
-
+                        # IN is not local
+            if delete_original:
+                cache_dir_fs.rm(cache_basename)
     return io_json
 
 

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -17,10 +17,9 @@ import hashlib
 import inspect
 import io
 import os
-import shutil
 from typing import Any, Dict, Union
 
-from . import cache, encode
+from . import cache, config, encode
 
 try:
     import dask
@@ -111,12 +110,13 @@ def dictify_io_object(
     )
 
     try:
-        open(io_json["file:local_path"], **open_kwargs)
+        config.get_cache_files_directory().open(io_json["href"], **open_kwargs)
     except:  # noqa: E722
+        config.get_cache_files_directory().put_file(obj.name, io_json["href"])
         if delete_original:
-            os.rename(obj.name, io_json["file:local_path"])
-        else:
-            shutil.copyfile(obj.name, io_json["file:local_path"])
+            # TODO: when cache is a local file system, then it would be better
+            # to mv rather than put then rm
+            os.remove(obj.name)
 
     return io_json
 

--- a/cacholote/extra_encoders.py
+++ b/cacholote/extra_encoders.py
@@ -111,19 +111,18 @@ def dictify_io_object(
         open_kwargs=open_kwargs,
     )
 
-    cache_dir = config.get_cache_files_directory()
-    local_path = io_json["file:local_path"]
-    basename = os.path.basename(io_json["file:local_path"])
+    cache_dir_fs = config.get_cache_files_directory()
+    local_path = io_json.get("file:local_path", None)
+    basename = io_json["href"].rsplit("/")[-1]
     try:
-        cache_dir.open(basename, **open_kwargs)
+        cache_dir_fs.open(
+            basename, **io_json["tmp:open_kwargs"], **io_json["tmp:storage_options"]
+        )
     except:  # noqa: E722
-        if (
-            isinstance(cache_dir.fs, fsspec.implementations.local.LocalFileSystem)
-            and delete_original
-        ):
+        if local_path is not None and delete_original:
             fsspec.filesystem("file").move(obj.name, local_path)
         else:
-            cache_dir.put_file(obj.name, basename)
+            cache_dir_fs.put_file(obj.name, basename)
             if delete_original:
                 fsspec.filesystem("file").rm(obj.name)
 

--- a/environment-minver.yml
+++ b/environment-minver.yml
@@ -6,5 +6,7 @@ dependencies:
 - pytest
 - pytest-cov
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW
+- aiohttp
 - diskcache
 - fsspec
+- requests

--- a/environment-minver.yml
+++ b/environment-minver.yml
@@ -7,3 +7,4 @@ dependencies:
 - pytest-cov
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW
 - diskcache
+- fsspec

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - sphinx
 - sphinx-autoapi
 # DO NOT EDIT ABOVE THIS LINE, ADD DEPENDENCIES BELOW
+- aiohttp
 - cfgrib
 - dask
 - diskcache
@@ -19,6 +20,7 @@ dependencies:
 - netCDF4
 - pip
 - python-magic
+- requests
 - xarray>=2022.6.0
 - zarr
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - cfgrib
 - dask
 - diskcache
+- fsspec
 - netCDF4
 - pip
 - pooch

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
 - fsspec
 - netCDF4
 - pip
-- pooch
 - python-magic
 - xarray>=2022.6.0
 - zarr

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 include_package_data = True
 install_requires =
     diskcache
+    fsspec
 
 [flake8]
 max-line-length = 110

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@ from cacholote import config
 
 @pytest.fixture(autouse=True)
 def set_tmpdir(tmpdir: str) -> None:
-    config.set(directory=tmpdir)
+    config.set(cache_db_directory=tmpdir)

--- a/tests/test_01_settings.py
+++ b/tests/test_01_settings.py
@@ -9,33 +9,35 @@ from cacholote import config
 def test_set_cache(tmpdir: str) -> None:
     newdir = os.path.join(tmpdir, "dummy")
     old_cache = config.SETTINGS["cache_store"]
-    new_cache = Cache(directory=newdir)
+    new_cache = Cache(cache_db_directory=newdir)
     assert old_cache is not new_cache
 
     with config.set(cache_store=new_cache):
         assert config.SETTINGS["cache_store"] is new_cache
-        assert config.SETTINGS["directory"] == newdir
+        assert config.SETTINGS["cache_db_directory"] is None
     assert config.SETTINGS["cache_store"] is old_cache
-    assert config.SETTINGS["directory"] == tmpdir
+    assert config.SETTINGS["cache_db_directory"] == tmpdir
 
     config.set(cache_store=new_cache)
     assert config.SETTINGS["cache_store"] is new_cache
-    assert config.SETTINGS["directory"] == newdir
+    assert config.SETTINGS["cache_db_directory"] is None
 
     with pytest.raises(
-        ValueError, match=r"'cache_store' is mutually exclusive with all other settings"
+        ValueError,
+        match=r"'cache_store' and 'cache_db_directory' are mutually exclusive",
     ):
-        config.set(cache_store=new_cache, directory="dummy")
+        config.set(cache_store=new_cache, cache_db_directory="dummy")
 
 
 def test_change_settings(tmpdir: str) -> None:
     newdir = os.path.join(tmpdir, "dummy")
-    config.set(directory=newdir)
-    assert config.SETTINGS["cache_store"].directory == newdir
 
-    with config.set(statistics=0):
-        assert config.SETTINGS["cache_store"].statistics == 0
-    assert config.SETTINGS["cache_store"].statistics == 1
+    with config.set(cache_db_directory=newdir):
+        assert config.SETTINGS["cache_store"].directory == newdir
+    assert config.SETTINGS["cache_store"].directory == tmpdir
+
+    config.set(cache_db_directory=newdir)
+    assert config.SETTINGS["cache_store"].directory == newdir
 
     with pytest.raises(KeyError, match="Wrong settings. Available settings: "):
         config.set(dummy="dummy")

--- a/tests/test_30_cache.py
+++ b/tests/test_30_cache.py
@@ -39,6 +39,8 @@ def test_cacheable(settings: Dict[str, Any]) -> None:
         cache_store = config.SETTINGS["cache_store"]
         is_redis = HAS_REDISLITE and isinstance(cache_store, redislite.Redis)
 
+        print(config.SETTINGS)
+
         cfunc = cache.cacheable(func)
         res = cfunc("test")
         assert res == {"a": "test", "args": [], "b": None, "kwargs": {}}

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -22,14 +22,11 @@ def func(a: T) -> T:
 
 @pytest.fixture
 def ds() -> xr.Dataset:
-    with fsspec.open(
-        "simplecache::https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib",
-        simplecache={"same_names": True},
-    ) as of:
+    url = "https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
+    with fsspec.open(f"simplecache::{url}", simplecache={"same_names": True}) as of:
         fname = of.name
     ds = xr.open_dataset(fname, engine="cfgrib")
     del ds.attrs["history"]
-
     return ds.sel(number=0)
 
 

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -49,7 +49,7 @@ def test_dictify_xr_dataset(
     )
     expected = {
         "type": xarray_cache_type,
-        "href": f"./285ee3a510a225620bb32d96ec20d19d9d91ae82be881e0b4c8320e4{extension}",
+        "href": local_path,
         "file:checksum": "285ee3a510a225620bb32d96ec20d19d9d91ae82be881e0b4c8320e4",
         "file:size": 470024,
         "file:local_path": local_path,

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -2,6 +2,7 @@ import glob
 import os
 from typing import TypeVar
 
+import fsspec
 import pytest
 
 from cacholote import cache, config, decode, encode, extra_encoders
@@ -21,13 +22,11 @@ def func(a: T) -> T:
 
 @pytest.fixture
 def ds() -> xr.Dataset:
-    import pooch
-
-    fname = pooch.retrieve(
-        url="https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib",
-        known_hash="c144fde61ca5d53702bf6f212775ef2cc783bdd66b6865160bf597c1b35ed898",
-    )
-    ds = xr.open_dataset(fname)
+    with fsspec.open(
+        "filecache::https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
+    ) as of:
+        fname = of.name
+    ds = xr.open_dataset(fname, engine="cfgrib")
     del ds.attrs["history"]
 
     return ds.sel(number=0)

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -23,7 +23,8 @@ def func(a: T) -> T:
 @pytest.fixture
 def ds() -> xr.Dataset:
     with fsspec.open(
-        "filecache::https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
+        "simplecache::https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib",
+        simplecache={"same_names": True},
     ) as of:
         fname = of.name
     ds = xr.open_dataset(fname, engine="cfgrib")

--- a/tests/test_40_xarray_encoders.py
+++ b/tests/test_40_xarray_encoders.py
@@ -34,7 +34,7 @@ def ds() -> xr.Dataset:
 
 xr_parametrize = (
     "xarray_cache_type,extension",
-    [("application/netcdf", ".nc"), ("application/wmo-GRIB2", ".grb2")],
+    [("application/x-netcdf", ".nc"), ("application/x-grib", ".grb")],
 )
 
 
@@ -67,7 +67,7 @@ def test_xr_roundtrip(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
         ds_json = encode.dumps(ds)
         res = decode.loads(ds_json)
 
-    if xarray_cache_type == "application/wmo-GRIB2":
+    if xarray_cache_type == "application/x-grib":
         xr.testing.assert_equal(res, ds)
     else:
         xr.testing.assert_identical(res, ds)
@@ -88,7 +88,7 @@ def test_xr_cacheable(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
         assert config.SETTINGS["cache_store"].stats() == (0, 1)
         mtime = os.path.getmtime(local_path)
 
-        if xarray_cache_type == "application/wmo-GRIB2":
+        if xarray_cache_type == "application/x-grib":
             xr.testing.assert_equal(res, ds)
         else:
             xr.testing.assert_identical(res, ds)
@@ -101,7 +101,7 @@ def test_xr_cacheable(ds: xr.Dataset, xarray_cache_type: str, extension: str) ->
             os.path.join(config.SETTINGS["cache_store"].directory, f"*{extension}")
         ) == [local_path]
 
-        if xarray_cache_type == "application/wmo-GRIB2":
+        if xarray_cache_type == "application/x-grib":
             xr.testing.assert_equal(res, ds)
         else:
             xr.testing.assert_identical(res, ds)

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -16,7 +16,7 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     tmpfile = os.path.join(tmpdir, "dummy.txt")
     with open(tmpfile, "w") as f:
         f.write("dummy")
-    checksum = str(fsspec.filesystem("file").checksum(tmpfile))
+    checksum = fsspec.filesystem("file").checksum(tmpfile)
 
     local_path = os.path.join(
         config.SETTINGS["cache_store"].directory,
@@ -41,7 +41,7 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
 
 def test_copy_file_to_cache_directory(tmpdir: str) -> None:
     url = "https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
-    checksum = "142252380851833733959491685103259827168"
+    checksum = 142252380851833733959491685103259827168
     cached_file = os.path.join(
         config.SETTINGS["cache_store"].directory, f"{checksum}.grib"
     )

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -13,6 +13,7 @@ def func(use_fsspec: bool) -> io.IOBase:
         fs = fsspec.filesystem("https")
         f: io.IOBase = fs.open(url, "rb")
         return f
+
     with fsspec.open(f"simplecache::{url}", simplecache={"same_names": True}) as of:
         return open(of.name, "rb")
 

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -7,7 +7,8 @@ from cacholote import cache, config, extra_encoders
 
 
 def func(url: str) -> fsspec.spec.AbstractBufferedFile:
-    return fsspec.open(url, "rb").open()
+    with fsspec.open(url, "rb") as f:
+        return f
 
 
 @pytest.mark.parametrize("delete_original", [True, False])

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -14,7 +14,8 @@ def func(a: T) -> T:
     return a
 
 
-def test_dictify_io_object(tmpdir: str) -> None:
+@pytest.mark.parametrize("delete_original", [True, False])
+def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     tmpfile = os.path.join(tmpdir, "dummy.txt")
     with open(tmpfile, "w") as f:
         f.write("dummy")
@@ -31,9 +32,12 @@ def test_dictify_io_object(tmpdir: str) -> None:
         "file:local_path": local_path,
         "tmp:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
     }
-    res = extra_encoders.dictify_io_object(open(tmpfile))
+    res = extra_encoders.dictify_io_object(
+        open(tmpfile), delete_original=delete_original
+    )
     assert res == expected
     assert os.path.exists(local_path)
+    assert os.path.exists(tmpfile) is not delete_original
 
 
 def test_copy_file_to_cache_directory(tmpdir: str) -> None:

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -1,3 +1,4 @@
+import io
 import os
 from typing import TypeVar
 
@@ -10,8 +11,8 @@ pytest.importorskip("magic")
 T = TypeVar("T")
 
 
-def func(a: T) -> T:
-    return a
+def func(path: str) -> io.TextIOWrapper:
+    return open(path, "r")
 
 
 @pytest.mark.parametrize("delete_original", [True, False])
@@ -43,32 +44,35 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
 
 def test_copy_file_to_cache_directory(tmpdir: str) -> None:
     tmpfile = os.path.join(tmpdir, "dummy.txt")
-    cached_file = os.path.join(
-        config.SETTINGS["cache_store"].directory,
-        "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7.txt",
-    )
-
     with open(tmpfile, "w") as f:
         f.write("dummy")
+
+    cached_file = os.path.join(
+        config.SETTINGS["cache_store"].directory,
+        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+    )
     cfunc = cache.cacheable(func)
 
-    res = cfunc(open(tmpfile))
+    res = cfunc(tmpfile)
     assert res.read() == "dummy"
     with open(cached_file, "r") as f:
         assert f.read() == "dummy"
     assert config.SETTINGS["cache_store"].stats() == (0, 1)
+    assert len(config.SETTINGS["cache_store"]) == 1
 
     # skip copying a file already in cache directory
     mtime = os.path.getmtime(cached_file)
-    res = cfunc(open(tmpfile))
+    res = cfunc(tmpfile)
     assert res.read() == "dummy"
     assert mtime == os.path.getmtime(cached_file)
     assert config.SETTINGS["cache_store"].stats() == (1, 1)
+    assert len(config.SETTINGS["cache_store"]) == 1
 
     # do not crash if cached file is removed
     os.remove(cached_file)
-    with pytest.warns(UserWarning):
-        res = cfunc(open(tmpfile))
+    with pytest.warns(UserWarning, match=f"No such file or directory: {cached_file!r}"):
+        res = cfunc(tmpfile)
     assert res.read() == "dummy"
     assert os.path.exists(cached_file)
     assert config.SETTINGS["cache_store"].stats() == (2, 1)
+    assert len(config.SETTINGS["cache_store"]) == 1

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -6,8 +6,6 @@ import pytest
 
 from cacholote import cache, config, extra_encoders
 
-pytest.importorskip("magic")
-
 T = TypeVar("T")
 
 

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -26,11 +26,12 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     )
     expected = {
         "type": "text/plain",
-        "href": "./f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        "href": local_path,
         "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
         "file:size": 5,
         "file:local_path": local_path,
         "tmp:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
+        "tmp:storage_options": {},
     }
     res = extra_encoders.dictify_io_object(
         open(tmpfile), delete_original=delete_original

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -1,16 +1,20 @@
 import io
 import os
-from typing import TypeVar
 
+import fsspec
 import pytest
 
 from cacholote import cache, config, extra_encoders
 
-T = TypeVar("T")
 
-
-def func(path: str) -> io.TextIOWrapper:
-    return open(path, "r")
+def func(use_fsspec: bool) -> io.IOBase:
+    url = "https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
+    if use_fsspec:
+        fs = fsspec.filesystem("https")
+        f: io.IOBase = fs.open(url, "rb")
+        return f
+    with fsspec.open(f"simplecache::{url}", simplecache={"same_names": True}) as of:
+        return open(of.name, "rb")
 
 
 @pytest.mark.parametrize("delete_original", [True, False])
@@ -40,28 +44,23 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     assert os.path.exists(tmpfile) is not delete_original
 
 
-def test_copy_file_to_cache_directory(tmpdir: str) -> None:
-    tmpfile = os.path.join(tmpdir, "dummy.txt")
-    with open(tmpfile, "w") as f:
-        f.write("dummy")
-
+@pytest.mark.parametrize("use_fsspec", [True, False])
+def test_copy_file_to_cache_directory(tmpdir: str, use_fsspec: bool) -> None:
+    checksum = "b8712c8338bf14a51f18b48294e9675289501d282c1f24d37d1a8995"
     cached_file = os.path.join(
-        config.SETTINGS["cache_store"].directory,
-        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        config.SETTINGS["cache_store"].directory, f"{checksum}.grib"
     )
     cfunc = cache.cacheable(func)
 
-    res = cfunc(tmpfile)
-    assert res.read() == "dummy"
-    with open(cached_file, "r") as f:
-        assert f.read() == "dummy"
+    res = cfunc(use_fsspec)
+    assert extra_encoders.hexdigestify_file(res) == checksum
     assert config.SETTINGS["cache_store"].stats() == (0, 1)
     assert len(config.SETTINGS["cache_store"]) == 1
 
     # skip copying a file already in cache directory
     mtime = os.path.getmtime(cached_file)
-    res = cfunc(tmpfile)
-    assert res.read() == "dummy"
+    res = cfunc(use_fsspec)
+    assert extra_encoders.hexdigestify_file(res) == checksum
     assert mtime == os.path.getmtime(cached_file)
     assert config.SETTINGS["cache_store"].stats() == (1, 1)
     assert len(config.SETTINGS["cache_store"]) == 1
@@ -69,8 +68,7 @@ def test_copy_file_to_cache_directory(tmpdir: str) -> None:
     # do not crash if cached file is removed
     os.remove(cached_file)
     with pytest.warns(UserWarning, match=f"No such file or directory: {cached_file!r}"):
-        res = cfunc(tmpfile)
-    assert res.read() == "dummy"
-    assert os.path.exists(cached_file)
+        res = cfunc(use_fsspec)
+    assert extra_encoders.hexdigestify_file(res) == checksum
     assert config.SETTINGS["cache_store"].stats() == (2, 1)
     assert len(config.SETTINGS["cache_store"]) == 1

--- a/tests/test_50_io_encoders.py
+++ b/tests/test_50_io_encoders.py
@@ -1,6 +1,4 @@
-import io
 import os
-from typing import Union
 
 import fsspec
 import pytest
@@ -8,17 +6,8 @@ import pytest
 from cacholote import cache, config, extra_encoders
 
 
-def func(
-    use_fsspec: bool,
-) -> Union[io.BufferedReader, fsspec.spec.AbstractBufferedFile]:
-    url = "https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
-    if use_fsspec:
-        fs = fsspec.filesystem("https")
-        f: fsspec.spec.AbstractBufferedFile = fs.open(url, "rb")
-        return f
-
-    with fsspec.open(f"simplecache::{url}", simplecache={"same_names": True}) as of:
-        return open(of.name, "rb")
+def func(url: str) -> fsspec.spec.AbstractBufferedFile:
+    return fsspec.open(url, "rb").open()
 
 
 @pytest.mark.parametrize("delete_original", [True, False])
@@ -26,15 +15,16 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     tmpfile = os.path.join(tmpdir, "dummy.txt")
     with open(tmpfile, "w") as f:
         f.write("dummy")
+    checksum = str(fsspec.filesystem("file").checksum(tmpfile))
 
     local_path = os.path.join(
         config.SETTINGS["cache_store"].directory,
-        "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a.txt",
+        f"{checksum}.txt",
     )
     expected = {
         "type": "text/plain",
         "href": local_path,
-        "file:checksum": "f6e6e2cc3b79d2ff7163fe28e6324870bfe8cf16a912dfc2ebceee7a",
+        "file:checksum": checksum,
         "file:size": 5,
         "file:local_path": local_path,
         "tmp:open_kwargs": {"encoding": "UTF-8", "errors": "strict", "mode": "r"},
@@ -48,25 +38,23 @@ def test_dictify_io_object(tmpdir: str, delete_original: bool) -> None:
     assert os.path.exists(tmpfile) is not delete_original
 
 
-@pytest.mark.parametrize("use_fsspec", [True, False])
-def test_copy_file_to_cache_directory(tmpdir: str, use_fsspec: bool) -> None:
-    checksum = "b8712c8338bf14a51f18b48294e9675289501d282c1f24d37d1a8995"
+def test_copy_file_to_cache_directory(tmpdir: str) -> None:
+    url = "https://github.com/ecmwf/cfgrib/raw/master/tests/sample-data/era5-levels-members.grib"
+    checksum = "142252380851833733959491685103259827168"
     cached_file = os.path.join(
         config.SETTINGS["cache_store"].directory, f"{checksum}.grib"
     )
     cfunc = cache.cacheable(func)
 
-    res = cfunc(use_fsspec)
+    res = cfunc(url)
     assert res.name == cached_file
-    assert extra_encoders.hexdigestify_file(res) == checksum
     assert config.SETTINGS["cache_store"].stats() == (0, 1)
     assert len(config.SETTINGS["cache_store"]) == 1
 
     # skip copying a file already in cache directory
     mtime = os.path.getmtime(cached_file)
-    res = cfunc(use_fsspec)
+    res = cfunc(url)
     assert res.name == cached_file
-    assert extra_encoders.hexdigestify_file(res) == checksum
     assert mtime == os.path.getmtime(cached_file)
     assert config.SETTINGS["cache_store"].stats() == (1, 1)
     assert len(config.SETTINGS["cache_store"]) == 1
@@ -74,8 +62,7 @@ def test_copy_file_to_cache_directory(tmpdir: str, use_fsspec: bool) -> None:
     # do not crash if cached file is removed
     os.remove(cached_file)
     with pytest.warns(UserWarning, match=f"No such file or directory: {cached_file!r}"):
-        res = cfunc(use_fsspec)
+        res = cfunc(url)
     assert res.name == cached_file
-    assert extra_encoders.hexdigestify_file(res) == checksum
     assert config.SETTINGS["cache_store"].stats() == (2, 1)
     assert len(config.SETTINGS["cache_store"]) == 1


### PR DESCRIPTION
Use fsspec to cache any file.
Also, I've simplified the settings available. We can restore db settings if/when we will need to handle better the database (e.g., set size/time limits, clear cache, ...)

TODO:
Use fsspec in the xarray encoder as well (Will do in a separate PR)